### PR TITLE
Energy sensors produced consumed

### DIFF
--- a/custom_components/came/pycame/devices/came_energy_sensor.py
+++ b/custom_components/came/pycame/devices/came_energy_sensor.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Optional
-
+from ..exceptions import ETIDomoUnmanagedDeviceError
 from .base import TYPE_ENERGY_SENSOR, CameDevice, DeviceState, StateType
 
 _LOGGER = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ class CameEnergySensor(CameDevice):
         self,
         manager,
         device_info: DeviceState,
-        update_cmd_base: str = "meters", #meters_list_req
+        update_cmd_base: str = "meters",
         update_src_field: str = "array",
         device_class: Optional[str] = None,
     ):
@@ -29,14 +29,37 @@ class CameEnergySensor(CameDevice):
 
     def update(self):
         """Update device state."""
-        self._force_update(self._update_cmd_base, self._update_src_field)
+        try:
+            self._force_update(self._update_cmd_base, self._update_src_field)
+        except ETIDomoUnmanagedDeviceError:
+            pass
 
+    def push_update(self, state: DeviceState):
+        """Update from ETI/Domo push data."""
+        if self._device_info.get("id") != state.get("id"):           
+            return
+            
+        updated = self.update_state(state)
+        if updated and hasattr(self, "hass_entity"):
+            self.hass_entity.async_write_ha_state()
+    
     @property
     def state(self) -> StateType:
-        """Return the current device state."""
-        return self._device_info.get("value")
+        """Return the current power in W."""
+        return self._device_info.get("instant_power")
 
     @property
     def unit_of_measurement(self) -> Optional[str]:
-        """Return the unit of measurement of this sensor, if any."""
-        return self._device_info.get("unit")
+        """Return the unit of measurement."""
+        return self._device_info.get("unit") or "W"
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return extra attributes for the sensor."""
+        return {
+            "produced": self._device_info.get("produced"),
+            "last_24h_avg": self._device_info.get("last_24h_avg"),
+            "last_month_avg": self._device_info.get("last_month_avg"),
+            "energy_unit": self._device_info.get("energy_unit"),
+        }
+

--- a/custom_components/came/sensor.py
+++ b/custom_components/came/sensor.py
@@ -1,26 +1,28 @@
 """Support for the CAME analog sensors."""
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+import logging
 from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
     ENTITY_ID_FORMAT,
     SensorEntity,
+    SensorStateClass,
+    SensorDeviceClass,
 )
-from homeassistant.components.sensor import SensorStateClass  # Importa la classe di stato corretta
-from homeassistant.config_entries import ConfigEntry  # Aggiungi questa importazione
-from homeassistant.const import (
-    PERCENTAGE,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import StateType
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import PRESSURE_UNITS, TEMPERATURE_UNITS
+
 from .pycame.came_manager import CameManager
 from .pycame.devices import CameDevice
-
+from .pycame.devices.came_energy_sensor import CameEnergySensor
 from .const import CONF_MANAGER, CONF_PENDING, DOMAIN, SIGNAL_DISCOVERY_NEW
 from .entity import CameEntity
-# Importa le classi di dispositivo corrette
-from homeassistant.components.sensor import SensorDeviceClass  # Aggiungi questo
+
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
@@ -31,7 +33,6 @@ async def async_setup_entry(
         """Discover and add a discovered CAME sensor."""
         if not dev_ids:
             return
-
         entities = await hass.async_add_executor_job(_setup_entities, hass, dev_ids)
         async_add_entities(entities)
 
@@ -42,7 +43,6 @@ async def async_setup_entry(
     devices_ids = hass.data[DOMAIN][CONF_PENDING].pop(SENSOR_DOMAIN, [])
     await async_discover_sensor(devices_ids)
 
-
 def _setup_entities(hass, dev_ids):
     """Set up CAME analog sensor device."""
     manager = hass.data[DOMAIN][CONF_MANAGER]  # type: CameManager
@@ -51,9 +51,19 @@ def _setup_entities(hass, dev_ids):
         device = manager.get_device_by_id(dev_id)
         if device is None:
             continue
-        entities.append(CameSensorEntity(device))
-    return entities
+        if isinstance(device, CameEnergySensor):
+            produced = 0
+            extra = device.extra_state_attributes
+            if isinstance(extra, dict):
+                produced = extra.get("produced", 0)
 
+            power_sensor = CameEnergySensorEntity(device)
+            energy_sensor = CameEnergyTotalSensorEntity(power_sensor, produced=produced)
+            entities.append(power_sensor)
+            entities.append(energy_sensor)
+        else:
+            entities.append(CameSensorEntity(device))
+    return entities
 
 class CameSensorEntity(CameEntity, SensorEntity):
     """CAME analog sensor device entity."""
@@ -62,22 +72,89 @@ class CameSensorEntity(CameEntity, SensorEntity):
         """Init CAME analog sensor device entity."""
         super().__init__(device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
-        # Modifica qui per utilizzare SensorStateClass
-        self._attr_state_class = SensorStateClass.MEASUREMENT  # Nuovo
-        # Sostituisci le vecchie costanti con SensorDeviceClass.*
-        self._attr_device_class = self._device.device_class or (
-            SensorDeviceClass.TEMPERATURE  # Sostituisci DEVICE_CLASS_TEMPERATURE (deprecato)
-            if self._device.unit_of_measurement in TEMPERATURE_UNITS
-            else SensorDeviceClass.HUMIDITY  # Sostituisci DEVICE_CLASS_HUMIDITY (deprecato)
-            if self._device.unit_of_measurement == PERCENTAGE
-            else SensorDeviceClass.PRESSURE  # Sostituisci DEVICE_CLASS_PRESSURE (deprecato)
-            if self._device.unit_of_measurement in PRESSURE_UNITS
-            else None
-        )
+        if self._device.unit_of_measurement == "%":
+            self._attr_device_class = SensorDeviceClass.HUMIDITY
+            self._attr_native_unit_of_measurement = PERCENTAGE
+        elif self._device.unit_of_measurement in TEMPERATURE_UNITS:
+            self._attr_device_class = SensorDeviceClass.TEMPERATURE
+            self._attr_native_unit_of_measurement = self._device.unit_of_measurement
+        elif self._device.unit_of_measurement in PRESSURE_UNITS:
+            self._attr_device_class = SensorDeviceClass.PRESSURE
+            self._attr_native_unit_of_measurement = self._device.unit_of_measurement
+        else:
+            self._attr_device_class = self._device.device_class
+            self._attr_native_unit_of_measurement = self._device.unit_of_measurement
+
         self._attr_unit_of_measurement = self._device.unit_of_measurement
 
     @property
     def state(self) -> StateType:
         """Return the state of the entity."""
         return self._device.state
+
+class CameEnergySensorEntity(CameEntity, SensorEntity):
+    """CAME energy sensor device entity."""
+
+    _attr_should_poll = True
+
+    def __init__(self, device: CameDevice):
+        """Init CAME energy sensor device entity."""
+        super().__init__(device)
+        device.hass_entity = self
+        self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_device_class = SensorDeviceClass.POWER
+        self._attr_native_unit_of_measurement = "W"
+
+    def update(self):
+        """Update the energy sensor entity."""
+        self._device.update()
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the current power."""
+        state = self._device.state
+        if isinstance(state, dict):
+            return state.get("produced")
+        return state
+
+    @property
+    def extra_state_attributes(self):
+        """Return the extra attributes."""
+        return self._device.extra_state_attributes or {}
+
+class CameEnergyTotalSensorEntity(CameEntity, SensorEntity):
+    """Sensor that integrates power to compute energy."""
+
+    def __init__(self, source_entity: CameEnergySensorEntity, produced: int = 0):
+        super().__init__(source_entity._device)
+        self._source_entity = source_entity
+        self._produced = produced
+
+        if produced == 1:
+            self._attr_name = f"{source_entity.name} Energia prodotta"
+            self._attr_unique_id = f"{source_entity.unique_id}_energy_produced"
+        else:
+            self._attr_name = f"{source_entity.name} Energia consumata"
+            self._attr_unique_id = f"{source_entity.unique_id}_energy_consumed"
+
+        self._attr_device_class = SensorDeviceClass.ENERGY
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = "kWh"
+        self._last_time = None
+        self._energy_total = 0.0
+
+    def update(self):
+        now = dt_util.utcnow()
+        power = self._source_entity.native_value
+        if self._last_time is not None and isinstance(power, (int, float)):
+            elapsed_hours = (now - self._last_time).total_seconds() / 3600
+            self._energy_total += (power * elapsed_hours) / 1000  # da W a kWh
+        self._last_time = now
+
+    @property
+    def native_value(self):
+        return round(self._energy_total, 3)
+


### PR DESCRIPTION
Introdotto il supporto alla distinzione tra energia prodotta e consumata rilevati da OH/GEN.
I valori `produced: true/false` vengono gestiti  tramite `sensor.py` e `came_energy_sensor.py`.
Testato e funzionante in impianto attualmente operativo.
