### PR TITLE
fix: address issue with encoding

### DIFF
--- a/custom_components/came/pycame/came_manager.py
+++ b/custom_components/came/pycame/came_manager.py
@@ -113,6 +113,7 @@ class CameManager:
             ) from exception
 
         try:
+            response.encoding = "utf-8"
             resp_json = response.json()
             ack_reason = resp_json.get("sl_data_ack_reason")
 


### PR DESCRIPTION
Addressed issue with encoding when loading the entities to home assistant.
Example:
![signal-2026-03-12-121357_002](https://github.com/user-attachments/assets/608b171d-e40e-4341-8016-ba67550d9b66)

@Den901 Hope this is okay. Let me know if you need something else.
